### PR TITLE
Properly handle "from" address and prioritise HTML emails

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,16 +30,27 @@ module.exports = {
 
     return {
       send: (options) => {
+        const getEmailFromAddress = () => {
+          if (!options.from) {
+            return settings.defaultFrom;
+          }
+
+          const regex = /[^< ]+(?=>)/g;
+          const matches = options.from.match(regex);
+          return matches.length ? matches[0] : settings.defaultFrom;
+        };
+
         return new Promise((resolve, reject) => {
           const client = Client.initWithMiddleware({
             debugLogging: false,
             authProvider: authProvider,
           });
 
+          const from = getEmailFromAddress();
           const mail = {
             subject: options.subject,
             from: {
-              emailAddress: { address: options.from || settings.defaultFrom },
+              emailAddress: { address: from },
             },
             toRecipients: [
               {
@@ -48,19 +59,19 @@ module.exports = {
                 },
               },
             ],
-            body: options.text
+            body: options.html
               ? {
-                  content: options.text,
-                  contentType: "text",
-                }
-              : {
                   content: options.html,
                   contentType: "html",
+                }
+              : {
+                  content: options.text,
+                  contentType: "text",
                 },
           };
 
           client
-            .api(`/users/${options.from || settings.defaultFrom}/sendMail`)
+            .api(`/users/${from}/sendMail`)
             .post({ message: mail })
             .then(resolve)
             .catch(reject);


### PR DESCRIPTION
The email templates in Strapi pass through the from address as `Name <example@email.com>`. This change handles parsing that correctly.

The frontend also sends both HTML and text emails through, so we're now prioritising sending the HTML version.